### PR TITLE
ReplyMarkup features + answerCallbackQuery method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /package-lock.php.yml
 /out/**
 /dn-sources/**
+.phpintel/**

--- a/README.MD
+++ b/README.MD
@@ -41,6 +41,73 @@ $listener->addListener(function($update){
 });
 $listener->start();
 ```
+### Использование клавиатуры
+#### Клавиатура под полем ввода (ReplyKeyboard)
+![ReplyKeyboard](https://sun9-45.userapi.com/c205624/v205624150/12151/u119tArN_LE.jpg)
+```php
+$api = new TelegramBotApi($bot_token);
+
+$keyboard = TMarkup::replyKeyboard()
+    ->button('Button 1')->button('Button 2')
+    ->row()
+    ->button('Row 2')->button('Hello world')->button('test 123')
+    ->row()
+    ->button('Button in row 3');
+
+$api->sendMessage()
+	->chat_id(123456)
+	->text('Hello world')
+	->reply_markup($keyboard)
+	->query();
+```
+
+#### Удаление клавиатуры под полем ввода (ReplyKeyboard)
+```php
+$api = new TelegramBotApi($bot_token);
+
+$hideKeyboard = TMarkup::removeKeyboard();
+
+$api->sendMessage()
+	->chat_id(123456)
+	->text('Hello world')
+	->reply_markup($hideKeyboard)
+	->query();
+```
+
+#### Клавиатура под сообщением (InlineKeyboard)
+![InlineKeyboard](https://sun9-59.userapi.com/c205624/v205624829/11e6f/itNoz8qnyFE.jpg)
+```php
+$api = new TelegramBotApi($bot_token);
+
+// Обязательно вторым аргументом у button указывать данные для callback_data или url-ссылку
+$keyboard = TMarkup::inlineKeyboard()
+    ->button('Button with callback', 'press_1')->button('Button 2', 'press_2')
+    ->row()
+    ->button('Link to google', 'https://google.com')->button('Link to git', 'http://github.com')
+    ->row()
+    ->button('1', 'btn_1')->button('2', 'btn_2')->button('3', 'btn_3')->button('4', 'btn_4')->button('5', 'btn_5')->button('6', 'btn_6')->button('7', 'btn_7')->button('8', 'btn_8');
+
+$api->sendMessage()
+	->chat_id(123456)
+	->text('Hello world')
+	->reply_markup($keyboard)
+	->query();
+```
+
+#### Ответ на сообщение (ForceReply)
+![ForceReply](https://sun9-23.userapi.com/c205624/v205624829/11e98/pyW0VWHtPJ0.jpg)
+```php
+$api = new TelegramBotApi($bot_token);
+
+$reply = TMarkup::forceReply();
+
+$api->sendMessage()
+	->chat_id(123456)
+	->text('Hello world')
+	->reply_markup($reply)
+	->query();
+```
+
 ## Расширение для DevelNext
 [Скачать](https://github.com/broelik/jphp-telegram-bot-api/releases/latest)
 

--- a/package.php.yml
+++ b/package.php.yml
@@ -1,5 +1,5 @@
 name: telegram-bot-api
-version: 1.0.0
+version: 1.1.0
 deps:
   jphp-core: '*'
   jphp-json-ext: '*'
@@ -19,6 +19,7 @@ config:
   - /.idea/**
   - /*.iml
   - /.git/**
+  - /.phpintel/**
   - /package.hub.yml
   - /bundle/**
   - /src-bundle/**

--- a/src/telegram/TelegramBotApi.php
+++ b/src/telegram/TelegramBotApi.php
@@ -17,6 +17,7 @@ use php\net\URL;
 use php\net\URLConnection;
 use telegram\exception\TelegramError;
 use telegram\exception\TelegramException;
+use telegram\query\TAnswerCallbackQuery;
 use telegram\query\TForwardMessageQuery;
 use telegram\query\TGetFileQuery;
 use telegram\query\TGetMeQuery;
@@ -161,6 +162,13 @@ class TelegramBotApi{
      */
     function getUpdates(){
         return new TGetUpdatesQuery($this);
+    }
+
+    /**
+     * @return TAnswerCallbackQuery
+     */
+    function answerCallbackQuery(){
+        return new TAnswerCallbackQuery($this);
     }
 
 

--- a/src/telegram/TelegramBotApi.php
+++ b/src/telegram/TelegramBotApi.php
@@ -196,10 +196,14 @@ class TelegramBotApi{
             else{
                 $connection->getOutputStream()->write($this->json->format($args));
             }
+
             if($connection->responseCode != 200){
-                throw new TelegramException("Server response invalid status code {$connection->responseCode}");
+                $rawResponse = $connection->getErrorStream()->readFully();
+                if(strlen($rawResponse) == 0) throw new TelegramException("Server response invalid status code {$connection->responseCode}");
+            } else {
+                $rawResponse = $connection->getInputStream()->readFully();
             }
-            $rawResponse = $connection->getInputStream()->readFully();
+
             $connection->disconnect();
             $response = $this->json->parse($rawResponse);
             if(!$response->ok){

--- a/src/telegram/object/TMarkup.php
+++ b/src/telegram/object/TMarkup.php
@@ -1,0 +1,38 @@
+<?php
+namespace telegram\object;
+
+use telegram\object\markup\TForceReply;
+use telegram\object\markup\TInlineKeyboard;
+use telegram\object\markup\TReplyKeyboard;
+use telegram\object\markup\TReplyKeyboardRemove;
+
+class TMarkup
+{	
+	/**
+	 * @return TReplyKeyboard
+	 */
+	public static function replyKeyboard(){
+		return new TReplyKeyboard;
+	}
+
+	/**
+	 * @return TInlineKeyboard
+	 */
+	public static function inlineKeyboard(){
+		return new TInlineKeyboard;
+	}
+
+	/**
+	 * @return TForceReply
+	 */
+	public static function forceReply(){
+		return new TForceReply;
+	}
+
+	/**
+	 * @return TReplyKeyboardRemove
+	 */
+	public static function removeKeyboard(){
+		return new TReplyKeyboardRemove;
+	}
+}

--- a/src/telegram/object/markup/AbstractMarkup.php
+++ b/src/telegram/object/markup/AbstractMarkup.php
@@ -1,0 +1,13 @@
+<?php
+namespace telegram\object\markup;
+
+class AbstractMarkup {
+	/**
+	 * @var array
+	 */
+	protected $markup = [];
+
+	public function getMarkup(): array {
+		return $this->markup;
+	}
+}

--- a/src/telegram/object/markup/TForceReply.php
+++ b/src/telegram/object/markup/TForceReply.php
@@ -1,0 +1,25 @@
+<?php
+namespace telegram\object\markup;
+
+/**
+ * --EN--
+ * Shows reply interface to the user, as if they manually selected the bot‘s message and tapped 'Reply'
+ * 
+ * @see https://core.telegram.org/bots/api#forcereply
+ */
+class TForceReply extends AbstractMarkup {
+	public function __construct(){
+		$this->markup['force_reply'] = true;
+	}
+
+	/**
+	 * --EN--
+	 * Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
+	 * 
+	 * @param bool $value 
+	 */
+	public function setSelective(bool $value){
+		$this->markup['selective'] = $value;
+		return $this;
+	}
+}

--- a/src/telegram/object/markup/TInlineKeyboard.php
+++ b/src/telegram/object/markup/TInlineKeyboard.php
@@ -1,0 +1,40 @@
+<?php
+namespace telegram\object\markup;
+
+/**
+ * --EN--
+ * This object represents an inline keyboard that appears right next to the message it belongs to.
+ *
+ * --RU--
+ * Отображает клавиатуру сразу под отправленным сообщением
+ * 
+ * @see https://core.telegram.org/bots/api#inlinekeyboardmarkup
+ */
+class TInlineKeyboard extends TReplyKeyboard {
+	/**
+	 * Добавить кнопку
+	 * @param  string   $text	Текст кнопки
+	 * @param  string 	$data 	Данные, которые будут возвращены при нажатии или ссылка для перехода
+	 * @return TInlineKeyboard
+	 */
+	public function button(string $text, string $data){
+		$btn = ['text' => $text];
+
+		if(strpos($data, 'http:') === 0 || strpos($data, 'https:') === 0){
+			$btn['url'] = $data;
+		} else {
+			$btn['callback_data'] = $data;
+		}
+
+		$this->buttons[$this->row][] = $btn;
+		
+		return $this;
+	}
+
+	public function getMarkup(): array {
+		$markup = $this->params;
+		$markup['inline_keyboard'] = $this->buttons;
+
+		return $markup;
+	}
+}

--- a/src/telegram/object/markup/TInlineKeyboard.php
+++ b/src/telegram/object/markup/TInlineKeyboard.php
@@ -1,6 +1,8 @@
 <?php
 namespace telegram\object\markup;
 
+use telegram\exception\TelegramException;
+
 /**
  * --EN--
  * This object represents an inline keyboard that appears right next to the message it belongs to.
@@ -12,17 +14,36 @@ namespace telegram\object\markup;
  */
 class TInlineKeyboard extends TReplyKeyboard {
 	/**
+	 * Callback data limit
+	 */
+	const MAX_CBDATA_LENGTH = 64;
+
+	/**
 	 * Добавить кнопку
 	 * @param  string   $text	Текст кнопки
 	 * @param  string 	$data 	Данные, которые будут возвращены при нажатии или ссылка для перехода
 	 * @return TInlineKeyboard
 	 */
-	public function button(string $text, string $data){
+	public function button(string $text){
 		$btn = ['text' => $text];
 
-		if(strpos($data, 'http:') === 0 || strpos($data, 'https:') === 0){
+		if(func_num_args() < 2){
+			throw new TelegramException('Parameter callback_data required for InlineKeyboard buttons');
+		} else {
+			$data = func_get_arg(1);
+		}
+
+		if(!is_string($data)){
+			throw new TelegramException('Parameter callback_data should be a string');
+		}
+
+		if(strpos($data, 'http:') === 0 || strpos($data, 'https:') === 0 || strpos($data, 'tg:') === 0){
 			$btn['url'] = $data;
 		} else {
+			if(strlen($data) > self::MAX_CBDATA_LENGTH){
+				throw new TelegramException('Parameter callback_data should be a string no more than ' . MAX_CBDATA_LENGTH . ' bytes in size');
+			}
+			
 			$btn['callback_data'] = $data;
 		}
 

--- a/src/telegram/object/markup/TReplyKeyboard.php
+++ b/src/telegram/object/markup/TReplyKeyboard.php
@@ -1,0 +1,99 @@
+<?php
+namespace telegram\object\markup;
+
+/**
+ * --EN--
+ * This object represents a custom keyboard with reply options 
+ *
+ * --RU--
+ * Отображает клавиатуру возле поля для ввода сообщения
+ * 
+ * @see https://core.telegram.org/bots/api#replykeyboardmarkup
+ */
+class TReplyKeyboard extends AbstractMarkup {
+
+	/**
+	 * @var array
+	 */
+	protected $params = [];
+
+	/**
+	 * Кнопки
+	 * @var array
+	 */
+	protected $buttons = [];
+
+	/**
+	 * Указатель текущей строки в кнопках
+	 * @var int
+	 */
+	protected $row = -1;
+
+	public function __construct(array $params = []){
+		$this->params = $params;
+		$this->row();
+	}
+
+	/**
+     * Добавить новую строку в панель кнопок
+	 * @return TReplyKeyboard
+	 */
+	public function row(){
+		$this->row++;
+		if(!isset($this->buttons[$this->row])) $this->buttons[$this->row] = [];
+
+		return $this;
+	}
+
+	/**
+	 * Добавить кнопку
+	 * @param  string      $text     			Текст кнопки
+	 * @return TReplyKeyboard
+	 */
+	public function button(string $text){
+		$this->buttons[$this->row][] = ['text' => $text];
+		
+		return $this;
+	}
+
+	/**
+	 * Указывает клиенту подогнать высоту клавиатуры под количество кнопок 
+	 * (сделать её меньше, если кнопок мало и наоборот)
+	 * @param bool $value 
+	 * @return TReplyKeyboard
+	 */
+	public function setResize(bool $value){
+		$this->params['resize_keyboard'] = $value;
+		return $this;
+	}
+
+	/**
+	 * Указывает клиенту скрыть клавиатуру после использования (после нажатия на кнопку). 
+	 * Её по-прежнему можно будет открыть через иконку в поле ввода сообщения.  
+	 * @param bool $value 
+	 * @return TReplyKeyboard
+	 */
+	public function setOneTime(bool $value){
+		$this->params['one_time_keyboard'] = $value;
+		return $this;
+	}
+
+	/**
+	 * @param bool $value 
+	 * @return TReplyKeyboard
+	 */
+	public function setSelective(bool $value){
+		$this->params['selective'] = $value;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getMarkup(): array {
+		$markup = $this->params;
+		$markup['keyboard'] = $this->buttons;
+
+		return $markup;
+	}
+}

--- a/src/telegram/object/markup/TReplyKeyboardRemove.php
+++ b/src/telegram/object/markup/TReplyKeyboardRemove.php
@@ -1,0 +1,25 @@
+<?php
+namespace telegram\object\markup;
+
+/**
+ * --EN--
+ * Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button
+ * 
+ * @see https://core.telegram.org/bots/api#replykeyboardremove
+ */
+class TReplyKeyboardRemove extends AbstractMarkup {
+	public function __construct(){
+		$this->markup['remove_keyboard'] = true;
+	}
+
+	/**
+	 * --EN--
+	 * Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
+	 * 
+	 * @param bool $value 
+	 */
+	public function setSelective(bool $value){
+		$this->markup['selective'] = $value;
+		return $this;
+	}
+}

--- a/src/telegram/query/TAnswerCallbackQuery.php
+++ b/src/telegram/query/TAnswerCallbackQuery.php
@@ -1,0 +1,78 @@
+<?php
+namespace telegram\query;
+
+
+use telegram\TelegramBotApi;
+use telegram\exception\TelegramException;
+use telegram\object\TMessage;
+use telegram\object\markup\AbstractMarkup;
+
+/**
+ * --EN--
+ * Use this method to send answers to callback queries sent from inline keyboards. The answer will be displayed to the user as a notification at the top of the chat screen or as an alert. On success, True is returned.
+ *
+ * --RU--
+ * Метод для ответа на callbackQuery, поступающий при нажатии на кнопку InlineKeyboard
+ * 
+ * @see https://core.telegram.org/bots/api#answercallbackquery
+ */
+class TAnswerCallbackQuery extends TBaseQuery {
+    public function __construct(TelegramBotApi $api){
+        parent::__construct($api, 'answerCallbackQuery', false);
+    }
+
+    /**
+     * --EN--
+     * Unique identifier for the query to be answered
+     * 
+     * @param string $value
+     * @return TAnswerCallbackQuery
+     */
+    public function callback_query_id(string $value){
+        return $this->put(__FUNCTION__, $value);
+    }
+
+    /**
+     * --EN--
+     * Text of the notification. If not specified, nothing will be shown to the user, 0-200 characters
+     * 
+     * @param string $value
+     * @return TAnswerCallbackQuery
+     */
+    public function text(string $value){
+        return $this->put(__FUNCTION__, $value);
+    }
+
+    /**
+     * --EN--
+     * URL that will be opened by the user's client. 
+     * 
+     * @param string $value
+     * @return TAnswerCallbackQuery
+     */
+    public function url(string $value){
+        return $this->put(__FUNCTION__, $value);
+    }
+    
+    /**
+     * --EN--
+     * If true, an alert will be shown by the client instead of a notification at the top of the chat screen. Defaults to false.
+     * 
+     * @param string $value
+     * @return TAnswerCallbackQuery
+     */
+    public function show_alert(bool $value){
+        return $this->put(__FUNCTION__, $value);
+    }
+
+    /**
+     * --EN--
+     * The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
+     * 
+     * @param string $value
+     * @return TAnswerCallbackQuery
+     */
+    public function cache_time(int $value){
+        return $this->put(__FUNCTION__, $value);
+    }
+}

--- a/src/telegram/query/TSendMessageQuery.php
+++ b/src/telegram/query/TSendMessageQuery.php
@@ -4,8 +4,10 @@
 namespace telegram\query;
 
 
-use telegram\object\TMessage;
 use telegram\TelegramBotApi;
+use telegram\exception\TelegramException;
+use telegram\object\TMessage;
+use telegram\object\markup\AbstractMarkup;
 
 class TSendMessageQuery extends TBaseQuery{
     public function __construct(TelegramBotApi $api){
@@ -47,11 +49,23 @@ class TSendMessageQuery extends TBaseQuery{
     public function reply_to_message_id($value){
         return $this->put(__FUNCTION__, (int)$value);
     }
-    /*
+    
+    /**
+     * @param array|TAbstractMarkup
+     * @return TSendMessageQuery
+     */
     public function reply_markup($value){
-        return $this->put(__FUNCTION__, $value);
+        if(is_array($value)){
+            return $this->put(__FUNCTION__, $value);
+        }
+        elseif($value instanceof AbstractMarkup){
+            return $this->put(__FUNCTION__, $value->getMarkup());
+        }
+        else {
+            throw new TelegramException('Invalid reply_markup parameter');
+        }
     }
-    */
+    
     /**
      * @return TMessage
      */


### PR DESCRIPTION
Добавил функции для работы с кнопками и метод answerCallbackQuery для ответа на запросы от кнопок

#### Клавиатура под полем ввода (ReplyKeyboard)
![ReplyKeyboard](https://sun9-45.userapi.com/c205624/v205624150/12151/u119tArN_LE.jpg)
```php
$api = new TelegramBotApi($bot_token);
$keyboard = TMarkup::replyKeyboard()
    ->button('Button 1')->button('Button 2')
    ->row()
    ->button('Row 2')->button('Hello world')->button('test 123')
    ->row()
    ->button('Button in row 3');
$api->sendMessage()
	->chat_id(123456)
	->text('Hello world')
	->reply_markup($keyboard)
	->query();
```

#### Удаление клавиатуры под полем ввода (ReplyKeyboard)
```php
$api = new TelegramBotApi($bot_token);
$hideKeyboard = TMarkup::removeKeyboard();
$api->sendMessage()
	->chat_id(123456)
	->text('Hello world')
	->reply_markup($hideKeyboard)
	->query();
```

#### Клавиатура под сообщением (InlineKeyboard)
![InlineKeyboard](https://sun9-59.userapi.com/c205624/v205624829/11e6f/itNoz8qnyFE.jpg)
```php
$api = new TelegramBotApi($bot_token);
// Обязательно вторым аргументом у button указывать данные для callback_data или url-ссылку
$keyboard = TMarkup::inlineKeyboard()
    ->button('Button with callback', 'press_1')->button('Button 2', 'press_2')
    ->row()
    ->button('Link to google', 'https://google.com')->button('Link to git', 'http://github.com')
    ->row()
    ->button('1', 'btn_1')->button('2', 'btn_2')->button('3', 'btn_3')->button('4', 'btn_4')->button('5', 'btn_5')->button('6', 'btn_6')->button('7', 'btn_7')->button('8', 'btn_8');
$api->sendMessage()
	->chat_id(123456)
	->text('Hello world')
	->reply_markup($keyboard)
	->query();
```

#### Ответ на сообщение (ForceReply)
![ForceReply](https://sun9-23.userapi.com/c205624/v205624829/11e98/pyW0VWHtPJ0.jpg)
```php
$api = new TelegramBotApi($bot_token);
$reply = TMarkup::forceReply();
$api->sendMessage()
	->chat_id(123456)
	->text('Hello world')
	->reply_markup($reply)
	->query();
```
